### PR TITLE
Added switches to the PTVFilter object when certain Filter values are…

### DIFF
--- a/PluginTraceViewer/PluginTraceViewer.cs
+++ b/PluginTraceViewer/PluginTraceViewer.cs
@@ -164,18 +164,22 @@ namespace Cinteros.XTB.PluginTraceViewer
                         {
                             case "plugin":
                                 result.Plugin = value;
+                                result.FilterPlugin = true;
                                 break;
 
                             case "message":
                                 result.Message = value;
+                                result.FilterMessage = true;
                                 break;
 
                             case "entity":
                                 result.Entity = value;
+                                result.FilterEntity = true;
                                 break;
 
                             case "correlationid":
                                 result.CorrelationId = value;
+                                result.FilterCorr = true;
                                 break;
 
                             case PluginTraceLog.RequestId:


### PR DESCRIPTION
I would like to use the Plugin Trace viewer from the Custom API Manager

The goal is to open the PTV with a given Custom API set as the Message filter

I figured out how to pass the 'Message' to the IMessageBusHost interface, but there needs to be a 'FilterMessage' property set to true in the PTVFilter object.

The current code doesn't do this.

This PR will set the FilterMessage to true if a value is passed.
I also added the same logic for other parameters : Plugin, Message, Entity, CorrelationId 