### PR TITLE
Add Time Delta column for correlation groups

### DIFF
--- a/PluginTraceViewer/Controls/GridControl.Designer.cs
+++ b/PluginTraceViewer/Controls/GridControl.Designer.cs
@@ -54,6 +54,7 @@
             this.tsmiShowColStartDate = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiShowColStartTime = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiShowColDuration = new System.Windows.Forms.ToolStripMenuItem();
+            this.tsmiShowColTimeDelta = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiShowColOperation = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiShowColPlugin = new System.Windows.Forms.ToolStripMenuItem();
             this.tsmiShowColStep = new System.Windows.Forms.ToolStripMenuItem();
@@ -100,6 +101,7 @@
             this.performanceexecutionstartdate = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.performanceexecutionstarttime = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.performanceexecutionduration = new System.Windows.Forms.DataGridViewTextBoxColumn();
+            this.timedelta = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.operationtype = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.typename = new System.Windows.Forms.DataGridViewTextBoxColumn();
             this.stepname = new System.Windows.Forms.DataGridViewTextBoxColumn();
@@ -135,6 +137,7 @@
             this.tsmiShowColStartDate,
             this.tsmiShowColStartTime,
             this.tsmiShowColDuration,
+            this.tsmiShowColTimeDelta,
             this.tsmiShowColOperation,
             this.tsmiShowColPlugin,
             this.tsmiShowColStep,
@@ -297,7 +300,18 @@
             this.tsmiShowColDuration.Tag = "performanceexecutionduration";
             this.tsmiShowColDuration.Text = "Duration";
             this.tsmiShowColDuration.CheckStateChanged += new System.EventHandler(this.tsmiShowColumn_CheckedChanged);
-            // 
+            //
+            // tsmiShowColTimeDelta
+            //
+            this.tsmiShowColTimeDelta.Checked = true;
+            this.tsmiShowColTimeDelta.CheckOnClick = true;
+            this.tsmiShowColTimeDelta.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.tsmiShowColTimeDelta.Name = "tsmiShowColTimeDelta";
+            this.tsmiShowColTimeDelta.Size = new System.Drawing.Size(163, 22);
+            this.tsmiShowColTimeDelta.Tag = "timedelta";
+            this.tsmiShowColTimeDelta.Text = "Time Delta";
+            this.tsmiShowColTimeDelta.CheckStateChanged += new System.EventHandler(this.tsmiShowColumn_CheckedChanged);
+            //
             // tsmiShowColOperation
             // 
             this.tsmiShowColOperation.Checked = true;
@@ -705,6 +719,7 @@
             this.performanceexecutionstartdate,
             this.performanceexecutionstarttime,
             this.performanceexecutionduration,
+            this.timedelta,
             this.operationtype,
             this.typename,
             this.stepname,
@@ -808,7 +823,14 @@
             this.performanceexecutionduration.Name = "performanceexecutionduration";
             this.performanceexecutionduration.ReadOnly = true;
             this.performanceexecutionduration.Width = 40;
-            // 
+            //
+            // timedelta
+            //
+            this.timedelta.HeaderText = "Time Delta";
+            this.timedelta.Name = "timedelta";
+            this.timedelta.ReadOnly = true;
+            this.timedelta.Width = 65;
+            //
             // operationtype
             // 
             this.operationtype.HeaderText = "Operation";
@@ -978,6 +1000,7 @@
         private System.Windows.Forms.ToolStripMenuItem tsmiShowColCreated;
         private System.Windows.Forms.ToolStripMenuItem tsmiShowColStartTime;
         private System.Windows.Forms.ToolStripMenuItem tsmiShowColDuration;
+        private System.Windows.Forms.ToolStripMenuItem tsmiShowColTimeDelta;
         private System.Windows.Forms.ToolStripMenuItem tsmiShowColOperation;
         private System.Windows.Forms.ToolStripMenuItem tsmiShowColPlugin;
         private System.Windows.Forms.ToolStripMenuItem tsmiShowColStep;
@@ -1026,6 +1049,7 @@
         private System.Windows.Forms.DataGridViewTextBoxColumn performanceexecutionstartdate;
         private System.Windows.Forms.DataGridViewTextBoxColumn performanceexecutionstarttime;
         private System.Windows.Forms.DataGridViewTextBoxColumn performanceexecutionduration;
+        private System.Windows.Forms.DataGridViewTextBoxColumn timedelta;
         private System.Windows.Forms.DataGridViewTextBoxColumn operationtype;
         private System.Windows.Forms.DataGridViewTextBoxColumn typename;
         private System.Windows.Forms.DataGridViewTextBoxColumn stepname;

--- a/PluginTraceViewer/PluginTraceViewer.cs
+++ b/PluginTraceViewer/PluginTraceViewer.cs
@@ -637,6 +637,7 @@ namespace Cinteros.XTB.PluginTraceViewer
         {
             FriendlyfyCorrelationIds(logs);
             SplittingStartDateTime(logs);
+            CalculateCorrelationTimeDelta(logs);
             SimplifyPluginTypes(logs);
             HidePluginsFromSteps(logs);
             HideEntitiesFromSteps(logs);
@@ -831,6 +832,75 @@ namespace Cinteros.XTB.PluginTraceViewer
                     entity["startdate"] = start;
                 }
             }
+        }
+
+        private void CalculateCorrelationTimeDelta(IEnumerable<Entity> entities)
+        {
+            var correlationStarts = new Dictionary<Guid, DateTime>();
+            var allCorrelationIds = new List<Guid>();
+            var multiCorrelationIds = new List<Guid>();
+
+            foreach (var entity in entities)
+            {
+                if (entity.Contains(PluginTraceLog.CorrelationId) && entity.Contains(PluginTraceLog.PerformanceExecutionStarttime))
+                {
+                    var corrId = (Guid)entity[PluginTraceLog.CorrelationId];
+                    var startTime = (DateTime)entity[PluginTraceLog.PerformanceExecutionStarttime];
+
+                    if (allCorrelationIds.Contains(corrId))
+                    {
+                        if (!multiCorrelationIds.Contains(corrId))
+                        {
+                            multiCorrelationIds.Add(corrId);
+                        }
+                    }
+                    else
+                    {
+                        allCorrelationIds.Add(corrId);
+                    }
+
+                    if (!correlationStarts.ContainsKey(corrId) || startTime < correlationStarts[corrId])
+                    {
+                        correlationStarts[corrId] = startTime;
+                    }
+                }
+            }
+
+            foreach (var entity in entities)
+            {
+                if (entity.Contains(PluginTraceLog.CorrelationId) &&
+                    entity.Contains(PluginTraceLog.PerformanceExecutionStarttime))
+                {
+                    var corrId = (Guid)entity[PluginTraceLog.CorrelationId];
+                    if (multiCorrelationIds.Contains(corrId))
+                    {
+                        var startTime = (DateTime)entity[PluginTraceLog.PerformanceExecutionStarttime];
+                        var deltaMs = (startTime - correlationStarts[corrId]).TotalMilliseconds;
+                        var deltaStr = FormatTimeDelta(deltaMs);
+                        if (entity.Contains("timedelta"))
+                        {
+                            entity["timedelta"] = deltaStr;
+                        }
+                        else
+                        {
+                            entity.Attributes.Add("timedelta", deltaStr);
+                        }
+                    }
+                }
+            }
+        }
+
+        private static string FormatTimeDelta(double totalMs)
+        {
+            if (totalMs < 1000)
+            {
+                return $"+{(int)totalMs} ms";
+            }
+            if (totalMs < 60000)
+            {
+                return $"+{totalMs / 1000:F1} s";
+            }
+            return $"+{totalMs / 60000:F1} min";
         }
 
         private void ExtractExceptionSummaries(IEnumerable<Entity> entities)
@@ -1465,6 +1535,7 @@ namespace Cinteros.XTB.PluginTraceViewer
                 "performanceexecutionstartdate",
                 "performanceexecutionstarttime",
                 "performanceexecutionduration",
+                "timedelta",
                 "operationtype",
                 "typename",
                 "stepname",


### PR DESCRIPTION
## Summary

- Adds a new **Time Delta** column to the trace log grid that shows the relative time offset from the earliest execution within the same correlation group
- For example, if three plugin steps share correlation "A", they display `+0 ms`, `+150 ms`, `+1.2 s` — making it immediately clear where time is spent in the execution chain
- Only populated when a correlation id appears more than once (consistent with the existing friendly correlation letter behavior)

## Implementation

- New `CalculateCorrelationTimeDelta` method in the `FixingLogRecords` pipeline, following the same two-pass pattern used by `FriendlyfyCorrelationIds`
- Smart formatting: `+N ms` for sub-second, `+N.N s` for sub-minute, `+N.N min` for longer deltas
- Column is visible by default, togglable via the grid context menu ("Time Delta"), and included in the detailed Excel export

## Motivation

When investigating performance issues in plugin execution chains, developers currently need to mentally calculate time differences between steps sharing the same correlation id. This column eliminates that overhead and makes bottleneck identification instant.

## Test plan

- [ ] Retrieve trace logs with multiple correlated plugin executions
- [ ] Verify Time Delta column shows `+0 ms` for the earliest step and increasing offsets for subsequent steps
- [ ] Verify single-occurrence correlation ids show no time delta (empty cell)
- [ ] Verify column visibility toggle works from the grid context menu
- [ ] Verify detailed Excel export includes the Time Delta column